### PR TITLE
Fix hatch build in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,23 @@ homepage = "https://github.com/bkmetzler/transactional"
 source = "vcs"
 path = "transactional/version.py"
 
+[tool.hatch.build]
+skip-excluded-dirs = true
+include = [
+  "transaction/**",
+  "pyproject.toml",
+  "*.md",
+  "noxfile.py",
+  ".pre-commit-config.yaml",
+  "tests/**",
+  "dev-requirements.txt"
+]
+exclude = [
+  "*.pyc",
+  "__pycache__/",
+  "dist",
+]
+
 [tool.hatch.envs.dev]
 dependencies = [
   "pytest",


### PR DESCRIPTION
- Added tool.hatch.build to pyproject.toml to allow for builds with hatch.
- Include only the files needed
- Exclude compiled and cached files.