### PR TITLE
[transaction] Clarify function type helpers and preserve rollback history

### DIFF
--- a/tests/test_helpers/test_function_type.py
+++ b/tests/test_helpers/test_function_type.py
@@ -1,0 +1,27 @@
+from transaction.helpers import FunctionType
+
+
+def test_is_supported_identifies_unsupported_types() -> None:
+    unsupported = [
+        FunctionType.LAMBDA_FUNCTION,
+        FunctionType.PARTIAL_FUNCTION,
+        FunctionType.GENERATOR_FUNCTION,
+        FunctionType.BUILTIN_FUNCTION,
+    ]
+    for func_type in unsupported:
+        assert not func_type.is_supported()
+
+
+def test_is_supported_allows_unknown_type() -> None:
+    assert FunctionType.UNKNOWN.is_supported()
+
+
+def test_is_callable_identifies_callable_types() -> None:
+    callable_types = [
+        FunctionType.ASYNC_FUNCTION,
+        FunctionType.COROUTINE_FUNCTION,
+        FunctionType.INSTANCE_METHOD,
+        FunctionType.REGULAR_FUNCTION,
+    ]
+    for func_type in callable_types:
+        assert func_type.is_callable()

--- a/tests/test_transaction_state/test_export_import.py
+++ b/tests/test_transaction_state/test_export_import.py
@@ -69,6 +69,7 @@ def test_export_import_history():
 
         state.rollback()
         json_data = state.export_history()
+        state.stack.clear()
         cleared_json = state.export_history()
     assert cleared_json == "[]"
     assert isinstance(json_data, str)
@@ -79,5 +80,5 @@ def test_export_import_history():
         assert len(txn.stack) == 2
         for call in txn.stack:
             assert call.name == "dummy_func"
-            assert call.rolled_back is False
+            assert call.rolled_back is True
             assert call.to_dict()["rollback_func"] == "test_export_import.rollback_func"

--- a/tests/test_transaction_state/test_sync_rollback.py
+++ b/tests/test_transaction_state/test_sync_rollback.py
@@ -17,4 +17,4 @@ async def test_sync_rollback_with_running_loop():
     state.rollback()
 
     assert ran == [True]
-    assert state.stack == []
+    assert [call.rolled_back for call in state.stack] == [True]

--- a/transaction/classes/transaction_state.py
+++ b/transaction/classes/transaction_state.py
@@ -80,7 +80,6 @@ class TransactionState:
                 True: Suppress exceptions
                 False:  Reraise exception
         """
-        print("__exit__", exc_type, exc_val, exc_tb)
         if exc_type:
             self.rollback()
         self.__end()
@@ -144,8 +143,6 @@ class TransactionState:
 
         for call in reversed(self.stack):
             await call.rollback()
-
-        self.stack.clear()
 
     def rollback(self) -> None:
         """

--- a/transaction/decorator.py
+++ b/transaction/decorator.py
@@ -57,7 +57,7 @@ def transaction(func: Callable[P, T]) -> Callable[P, T | Awaitable[T]]:
             if isinstance(func, classmethod):
                 raise TypeError("@transaction must be applied before @classmethod")
             return ClassTransactionMethod(func)  # type: ignore[return-value]
-        if not func_type.is_not_supported():
+        if not func_type.is_supported():
             raise ValueError(f"UNSUPPORTED TYPE: {func_type}")
         raise ValueError(f"UNKNOWN TYPE: {func_type}")
 

--- a/transaction/helpers.py
+++ b/transaction/helpers.py
@@ -21,24 +21,20 @@ class FunctionType(Enum):
     UNKNOWN = auto()
 
     def is_callable(self) -> bool:
-        if self in (
+        return self in {
             FunctionType.ASYNC_FUNCTION,
             FunctionType.COROUTINE_FUNCTION,
             FunctionType.INSTANCE_METHOD,
             FunctionType.REGULAR_FUNCTION,
-        ):
-            return True
-        return False
+        }
 
-    def is_not_supported(self) -> bool:
-        if self in (
+    def is_supported(self) -> bool:
+        return self not in {
             FunctionType.LAMBDA_FUNCTION,
             FunctionType.PARTIAL_FUNCTION,
             FunctionType.GENERATOR_FUNCTION,
             FunctionType.BUILTIN_FUNCTION,
-        ):
-            return False
-        return True
+        }
 
 
 def get_function_type(ctx: Any, func: Callable) -> FunctionType:  # type: ignore[type-arg]


### PR DESCRIPTION
## Summary
- simplify function type checks with `is_supported` and set membership
- stop clearing rollback history and drop stray debug output
- add tests for function type helpers and rollback preservation

## Testing
- `pre-commit run --files transaction/helpers.py transaction/decorator.py transaction/classes/transaction_state.py tests/test_helpers/test_function_type.py tests/test_transaction_state/test_export_import.py tests/test_transaction_state/test_sync_rollback.py`
- `nox -s tests` *(fail: InterpreterNotFound: python3.11, InterpreterNotFound: python3.13)*


------
https://chatgpt.com/codex/tasks/task_e_6892566e7efc832da7cf32d7bfcaa2b1