### PR TITLE
[transaction] Improve Pythonic style and add tests

### DIFF
--- a/tests/test_helpers/test_function_type.py
+++ b/tests/test_helpers/test_function_type.py
@@ -1,0 +1,11 @@
+from transaction.helpers import FunctionType
+
+
+def test_is_callable() -> None:
+    assert FunctionType.REGULAR_FUNCTION.is_callable() is True
+    assert FunctionType.CLASS_METHOD.is_callable() is False
+
+
+def test_is_not_supported() -> None:
+    assert FunctionType.LAMBDA_FUNCTION.is_not_supported() is False
+    assert FunctionType.REGULAR_FUNCTION.is_not_supported() is True

--- a/tests/test_transaction_state/test_get_current.py
+++ b/tests/test_transaction_state/test_get_current.py
@@ -1,0 +1,12 @@
+from transaction.classes.transaction_state import TransactionState
+
+
+def test_get_current_returns_state() -> None:
+    token = TransactionState._current_state.set(None)
+    try:
+        assert TransactionState.get_current() is None
+        with TransactionState() as state:
+            assert TransactionState.get_current() is state
+        assert TransactionState.get_current() is None
+    finally:
+        TransactionState._current_state.reset(token)

--- a/transaction/classes/function_call.py
+++ b/transaction/classes/function_call.py
@@ -55,13 +55,12 @@ class FunctionCall:
             else:
                 result = self.rollback_func(*self.args, **self.kwargs)
 
-            if inspect.iscoroutine(result) or inspect.isawaitable(result):
+            if inspect.isawaitable(result):
                 await result
             self.rolled_back = True
         except Exception as e:
             self.exception = f"{type(e).__name__}: {e}"
             raise
-        self.rolled_back = True
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/transaction/classes/transaction_state.py
+++ b/transaction/classes/transaction_state.py
@@ -80,7 +80,6 @@ class TransactionState:
                 True: Suppress exceptions
                 False:  Reraise exception
         """
-        print("__exit__", exc_type, exc_val, exc_tb)
         if exc_type:
             self.rollback()
         self.__end()
@@ -213,8 +212,7 @@ class TransactionState:
             TransactionState
         """
         transaction_state = cls()
-        transaction_state.stack.clear()
-        transaction_state.stack.extend([FunctionCall.from_dict(item) for item in json.loads(json_str)])
+        transaction_state.stack = [FunctionCall.from_dict(item) for item in json.loads(json_str)]
         return transaction_state
 
     @classmethod
@@ -225,7 +223,4 @@ class TransactionState:
             TransactionState | None
 
         """
-        state = cls._current_state.get()
-        if state is None:
-            return None
-        return state
+        return cls._current_state.get()

--- a/transaction/helpers.py
+++ b/transaction/helpers.py
@@ -21,24 +21,20 @@ class FunctionType(Enum):
     UNKNOWN = auto()
 
     def is_callable(self) -> bool:
-        if self in (
+        return self in {
             FunctionType.ASYNC_FUNCTION,
             FunctionType.COROUTINE_FUNCTION,
             FunctionType.INSTANCE_METHOD,
             FunctionType.REGULAR_FUNCTION,
-        ):
-            return True
-        return False
+        }
 
     def is_not_supported(self) -> bool:
-        if self in (
+        return self not in {
             FunctionType.LAMBDA_FUNCTION,
             FunctionType.PARTIAL_FUNCTION,
             FunctionType.GENERATOR_FUNCTION,
             FunctionType.BUILTIN_FUNCTION,
-        ):
-            return False
-        return True
+        }
 
 
 def get_function_type(ctx: Any, func: Callable) -> FunctionType:  # type: ignore[type-arg]
@@ -91,6 +87,4 @@ def inspect_function(func: Callable) -> FunctionType:  # type: ignore[type-arg]
 
 
 def get_class(func: Callable) -> Any:  # type:ignore[type-arg]
-    if hasattr(func, "__class__"):
-        return func.__class__
-    return func
+    return getattr(func, "__class__", func)


### PR DESCRIPTION
## Summary
- streamline FunctionType helpers with cleaner membership checks
- simplify rollback logic using `inspect.isawaitable`
- tidy TransactionState context handling and history import

## Testing
- `pre-commit run --files transaction/helpers.py transaction/classes/function_call.py transaction/classes/transaction_state.py tests/test_transaction_state/test_get_current.py tests/test_helpers/test_function_type.py tests/test_helpers/__init__.py`
- `nox -s tests -p 3.12`

------
https://chatgpt.com/codex/tasks/task_e_689360b20988832d8ef601765f403b87