### PR TITLE
[transaction] Add comprehensive tests for coverage

### DIFF
--- a/tests/test_decorator/test_transaction_decorator_additional.py
+++ b/tests/test_decorator/test_transaction_decorator_additional.py
@@ -1,0 +1,74 @@
+import pytest
+
+from transaction.decorator import ClassTransactionMethod
+from transaction.decorator import StaticTransactionMethod
+from transaction.decorator import transaction
+from transaction.decorator import TransactionWrapper
+from transaction.helpers import FunctionType
+
+
+def test_transaction_staticmethod_wrong_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    sm = staticmethod(lambda: None)
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.STATIC_METHOD)
+    with pytest.raises(TypeError):
+        transaction(sm)
+
+
+def test_transaction_staticmethod_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    def func() -> None:
+        pass
+
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.STATIC_METHOD)
+    wrapped = transaction(func)
+    assert isinstance(wrapped, StaticTransactionMethod)
+
+    @wrapped.rollback
+    def rb() -> None:
+        pass
+
+
+def test_transaction_classmethod_wrong_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    cm = classmethod(lambda cls: None)
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.CLASS_METHOD)
+    with pytest.raises(TypeError):
+        transaction(cm)
+
+
+def test_transaction_classmethod_wrapper(monkeypatch: pytest.MonkeyPatch) -> None:
+    def func(cls) -> int:  # type: ignore[no-untyped-def]
+        return 1
+
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.CLASS_METHOD)
+    wrapped = transaction(func)
+    assert isinstance(wrapped, ClassTransactionMethod)
+
+    @wrapped.rollback
+    def rb(cls) -> None:  # type: ignore[no-untyped-def]
+        pass
+
+
+def test_transaction_unsupported_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.LAMBDA_FUNCTION)
+    with pytest.raises(ValueError, match="UNSUPPORTED TYPE"):
+        transaction(lambda: None)
+
+
+def test_transaction_unknown_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.UNKNOWN)
+    with pytest.raises(ValueError, match="UNKNOWN TYPE"):
+        transaction(lambda: None)
+
+
+def test_wrapper_class_method_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Dummy:
+        called = None
+
+    def cls_func(cls, val: int) -> int:
+        Dummy.called = val
+        return val
+
+    wrapper = TransactionWrapper(cls_func)
+    monkeypatch.setattr("transaction.decorator.inspect_function", lambda f: FunctionType.CLASS_METHOD)
+    monkeypatch.setattr("transaction.decorator.get_class", lambda f: Dummy)
+    assert wrapper(5) == 5
+    assert Dummy.called == 5

--- a/tests/test_function_call/test_function_call_additional.py
+++ b/tests/test_function_call/test_function_call_additional.py
@@ -1,0 +1,50 @@
+import pytest
+
+from transaction.classes.function_call import FunctionCall
+
+
+def test_str_representation() -> None:
+    call = FunctionCall(name="foo", args=(1,), kwargs={})
+    assert str(call) == "foo(args=(1,), kwargs={})"
+
+
+@pytest.mark.asyncio
+async def test_rollback_no_function() -> None:  # type: ignore[return-value]
+    call = FunctionCall(name="foo", args=(), kwargs={})
+    with pytest.raises(RuntimeError, match="No rollback function"):
+        await call.rollback()
+    assert call.exception is not None
+
+
+@pytest.mark.asyncio
+async def test_rollback_classmethod_awaitable() -> None:  # type: ignore[return-value]
+    class Handler:
+        called_with: tuple[int, ...] | None = None
+
+        @classmethod
+        def rollback(cls, *nums: int):
+            async def inner() -> None:
+                cls.called_with = nums
+
+            return inner()
+
+    call = FunctionCall(
+        name="do",
+        args=(1, 2),
+        kwargs={},
+        rollback_func=Handler.rollback,
+    )
+    await call.rollback()
+    assert call.rolled_back is True
+    assert Handler.called_with[1:] == (1, 2)
+
+
+def test_json_and_pickle_roundtrip() -> None:
+    call = FunctionCall(name="foo", args=(1, 2), kwargs={})
+    json_str = call.to_json()
+    call_from_json = FunctionCall.from_json(json_str)
+    assert call_from_json.name == "foo"
+
+    pickled = call.to_pickle()
+    unpickled = FunctionCall.from_pickle(pickled)
+    assert unpickled.name == "foo"

--- a/tests/test_helpers/test_get_function_type_comprehensive.py
+++ b/tests/test_helpers/test_get_function_type_comprehensive.py
@@ -1,0 +1,83 @@
+import functools
+import inspect
+
+import pytest
+
+from transaction.helpers import FunctionType
+from transaction.helpers import get_class
+from transaction.helpers import get_function_type
+
+
+def test_get_function_type_variants() -> None:
+    def sample(a: int, b: int) -> int:
+        return a + b
+
+    partial_func = functools.partial(sample, 1)
+    assert get_function_type(None, partial_func) is FunctionType.PARTIAL_FUNCTION
+
+    assert get_function_type(None, len) is FunctionType.BUILTIN_FUNCTION
+
+    async def coro() -> None:
+        pass
+
+    c = coro()
+    try:
+        assert get_function_type(None, c) is FunctionType.COROUTINE_FUNCTION
+    finally:
+        c.close()
+
+    def gen() -> int:
+        yield 1
+
+    assert get_function_type(None, gen) is FunctionType.GENERATOR_FUNCTION
+
+    class Demo:
+        def inst(self) -> None:
+            pass
+
+        @classmethod
+        def cls(cls) -> None:
+            pass
+
+    demo = Demo()
+    assert get_function_type(demo, demo.inst) is FunctionType.INSTANCE_METHOD
+    assert get_function_type(Demo, Demo.cls) is FunctionType.CLASS_METHOD
+
+    assert get_function_type(None, lambda x: x) is FunctionType.LAMBDA_FUNCTION
+
+    assert get_function_type(None, object()) is FunctionType.UNKNOWN
+
+
+def test_get_function_type_class_hierarchy(monkeypatch: pytest.MonkeyPatch) -> None:
+    class Container:
+        @staticmethod
+        def sm() -> None:
+            pass
+
+        @classmethod
+        def cm(cls) -> None:
+            pass
+
+        def reg(self) -> None:
+            pass
+
+    class Dummy:
+        def __init__(self, name: str) -> None:
+            self.__name__ = name
+
+    monkeypatch.setattr(inspect, "isfunction", lambda obj: isinstance(obj, Dummy))
+    monkeypatch.setattr(inspect, "iscoroutinefunction", lambda obj: False)
+    monkeypatch.setattr(inspect, "iscoroutine", lambda obj: False)
+    monkeypatch.setattr(inspect, "isgeneratorfunction", lambda obj: False)
+    monkeypatch.setattr(inspect, "ismethod", lambda obj: False)
+
+    assert get_function_type(Container, Dummy("sm")) is FunctionType.STATIC_METHOD
+    assert get_function_type(Container, Dummy("cm")) is FunctionType.CLASS_METHOD
+    assert get_function_type(Container, Dummy("reg")) is FunctionType.REGULAR_FUNCTION
+
+
+def test_get_class() -> None:
+    def sample() -> None:
+        pass
+
+    assert get_class(sample) is sample.__class__

--- a/tests/test_transaction_state/test_transaction_state_additional.py
+++ b/tests/test_transaction_state/test_transaction_state_additional.py
@@ -1,0 +1,17 @@
+import pytest
+
+from transaction.classes.function_call import FunctionCall
+from transaction.classes.transaction_state import TransactionState
+
+
+@pytest.mark.asyncio
+async def test_rollback_in_running_loop() -> None:  # type: ignore[return-value]
+    def failing() -> None:
+        raise ValueError("fail")
+
+    call = FunctionCall(name="f", args=(), kwargs={}, rollback_func=failing)
+    state = TransactionState()
+    state.record_call(call)
+
+    with pytest.raises(ValueError, match="fail"):
+        state.rollback()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,5 @@
+from transaction import version
+
+
+def test_version_constant() -> None:
+    assert version.__version__ == "0.0.1"


### PR DESCRIPTION
## Summary
- Add tests for FunctionCall, including classmethod rollback and serialization
- Exercise decorator edge cases and class wrapper call path
- Expand helper coverage for function type detection
- Test rollback behavior within running event loop
- Verify package version constant

## Testing
- `pre-commit run --files tests/test_helpers/test_get_function_type_comprehensive.py tests/test_function_call/test_function_call_additional.py tests/test_transaction_state/test_transaction_state_additional.py tests/test_decorator/test_transaction_decorator_additional.py tests/test_version.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68936cc3e678832d98747bff326e2136