### PR TITLE
[transaction] Add README example tests

### DIFF
--- a/tests/examples/test_example_1.py
+++ b/tests/examples/test_example_1.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from transaction import transaction
+from transaction import TransactionState
+
+
+def test_example_1() -> None:
+    events: list[str] = []
+
+    @transaction
+    def step(i: int) -> int:
+        events.append(f"step:{i}")
+        return i
+
+    @step.rollback
+    def rollback_step(i: int) -> bool:
+        events.append(f"rollback_step:{i}")
+        return True
+
+    @transaction
+    def raise_except(j: str) -> str:
+        events.append(f"raise_except:{j}")
+        raise Exception("Random Exception")
+
+    @raise_except.rollback
+    def undo_raise_exception(j: str) -> bool:
+        events.append(f"undo_raise_exception:{j}")
+        return True
+
+    with TransactionState(reraise=False):
+        step(1)
+        step(2)
+        step(3)
+        raise_except("random string")
+
+    assert events == [
+        "step:1",
+        "step:2",
+        "step:3",
+        "raise_except:random string",
+        "undo_raise_exception:random string",
+        "rollback_step:3",
+        "rollback_step:2",
+        "rollback_step:1",
+    ]

--- a/tests/examples/test_example_2.py
+++ b/tests/examples/test_example_2.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from transaction import transaction
+from transaction import TransactionState
+
+
+def test_example_2() -> None:
+    executed = {"rollback_int": False, "rollback_str": False}
+
+    @transaction
+    def step_int(i: int) -> int:
+        return i
+
+    @step_int.rollback
+    def rollback_step_int(i: int) -> bool:
+        executed["rollback_int"] = True
+        return True
+
+    @transaction
+    def step_str(j: str) -> str:
+        return j
+
+    @step_str.rollback
+    def rollback_step_str(j: str) -> bool:
+        executed["rollback_str"] = True
+        return True
+
+    with TransactionState() as state:
+        assert step_int(1) == 1
+        assert step_str("2") == "2"
+
+    assert len(state.stack) == 2
+    assert executed == {"rollback_int": False, "rollback_str": False}

--- a/tests/examples/test_example_3.py
+++ b/tests/examples/test_example_3.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+from transaction import transaction
+from transaction import TransactionState
+
+
+@pytest.mark.asyncio
+async def test_example_3() -> None:
+    events: list[str] = []
+
+    @transaction
+    async def step(i: int) -> int:
+        events.append(f"step:{i}")
+        return i
+
+    @step.rollback
+    def rollback_step(i: int) -> bool:
+        events.append(f"rollback_step:{i}")
+        return True
+
+    @transaction
+    def raise_except(j: str) -> str:
+        events.append(f"raise_except:{j}")
+        raise Exception("Random Exception")
+
+    @raise_except.rollback
+    async def undo_raise_exception(j: str) -> bool:
+        events.append(f"undo_raise_exception:{j}")
+        return True
+
+    class MyClass:
+        @staticmethod
+        @transaction
+        def staticmethod_call(i: int) -> int:
+            events.append(f"staticmethod_call:{i}")
+            return i
+
+        @classmethod
+        @transaction
+        def classmethod_call(cls, j: str) -> str:
+            events.append(f"classmethod_call:{j}")
+            return j
+
+        @transaction
+        def instancemethod_call(self, k: list | None = None) -> list | None:  # not supported
+            return k
+
+    @MyClass.staticmethod_call.rollback
+    def rollback_staticmethod(i: int) -> bool:
+        events.append(f"rollback_staticmethod:{i}")
+        return True
+
+    @MyClass.classmethod_call.rollback
+    def rollback_classmethod(cls, j: str) -> bool:
+        events.append(f"rollback_classmethod:{j}")
+        return True
+
+    with TransactionState(reraise=False):
+        await step(1)
+        MyClass.staticmethod_call(2)
+        MyClass.classmethod_call("test string")
+        raise_except("boom")
+
+    assert events == [
+        "step:1",
+        "staticmethod_call:2",
+        "classmethod_call:test string",
+        "raise_except:boom",
+        "undo_raise_exception:boom",
+        "rollback_classmethod:test string",
+        "rollback_staticmethod:2",
+        "rollback_step:1",
+    ]
+
+    mc = MyClass()
+    assert mc.instancemethod_call([1, 2, 3]) is None
+
+    with pytest.raises(ValueError):
+        transaction(lambda x: x + 1)

--- a/tests/examples/test_example_5.py
+++ b/tests/examples/test_example_5.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from transaction import transaction
+from transaction import TransactionState
+
+
+@pytest.mark.asyncio
+async def test_example_5() -> None:
+    calls: list[int] = []
+
+    @transaction
+    def step1(i: int) -> int:
+        calls.append(i)
+        return i
+
+    @step1.rollback
+    def step1_rollback(i: int) -> bool:
+        calls.append(-i)
+        return True
+
+    async with TransactionState() as state:
+        step1(1)
+        step1(2)
+        step1(3)
+
+    assert calls == [1, 2, 3]
+    assert len(state.stack) == 3

--- a/tests/examples/test_example_6.py
+++ b/tests/examples/test_example_6.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from transaction import transaction
+from transaction import TransactionState
+
+
+@transaction
+def step1(i: int) -> int:
+    return i
+
+
+@step1.rollback
+def step1_rollback(i: int) -> bool:
+    return True
+
+
+def test_example_6() -> None:
+    with TransactionState() as state:
+        step1(1)
+        step1(2)
+        step1(3)
+        export_json_str = state.export_history()
+
+    with TransactionState.import_history(export_json_str) as imported_state:
+        step1(4)
+        step1(5)
+        step1(6)
+
+    assert len(state.stack) == 3
+    assert len(imported_state.stack) == 6

--- a/tests/examples/test_example_7.py
+++ b/tests/examples/test_example_7.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from transaction import transaction
+
+
+def test_example_7() -> None:
+    class MyClass:
+        @staticmethod
+        @transaction
+        def static_method(i: int) -> int:
+            return i
+
+        @classmethod
+        @transaction
+        def class_method(cls, j: str) -> str:
+            return j
+
+    assert MyClass.static_method(5) == 5
+    assert MyClass.class_method("hi") == "hi"
+
+    def define_bad_class() -> None:
+        class BadClass:
+            """Simple container for testing decorator order."""
+
+            @transaction
+            @staticmethod
+            def method(i: int) -> int:
+                return i
+
+        BadClass()  # pragma: no cover - instantiation for side effects
+
+    with pytest.raises(ValueError):
+        define_bad_class()


### PR DESCRIPTION
## Summary
- add unit tests mirroring examples from README

## Testing
- `pre-commit run --files tests/examples/test_example_3.py tests/examples/test_example_7.py tests/examples/test_example_6.py tests/examples/test_example_1.py tests/examples/test_example_2.py tests/examples/test_example_5.py`
- `pytest tests/examples`


------
https://chatgpt.com/codex/tasks/task_e_6893749f8514832db2489e4160d5e0cd